### PR TITLE
docs: ContextBridge 해커톤 데크 추가 + study 페이지 발표 자료 카드 연결

### DIFF
--- a/docs/pages/practical_ai_study.html
+++ b/docs/pages/practical_ai_study.html
@@ -353,6 +353,13 @@
           <p>AI가 코드·문서에서 근거를 먼저 검색해 확인한 뒤 답하도록 만드는 RAG 개념을 Camera HAL 관점으로 정리한 발표 슬라이드 — 정의, grep vs RAG, Vector DB와의 차이, 5개 강제 장치, CLAUDE.md 규칙, Hybrid RAG, 도입 로드맵</p>
           <span>프로젝트 발표 데크</span>
         </a>
+
+        <a class="resource" href="contextbridge-presentation.html" target="_blank" rel="noopener noreferrer">
+          <div class="label">해커톤</div>
+          <strong>ContextBridge — Cross-layer 디버깅 근거 시스템</strong>
+          <p>7곳을 뒤지던 Camera HAL 디버깅을 질문 한 번으로 — 하나의 증상을 layer를 따라 추적해 근거 패키지로 묶어주는 해커톤 프로젝트 데크. Before/After, 데모, 아키텍처(수집·최신 유지·Cross-layer 검색·근거 패키지), 4주 계획, Evidence Pack, 역할 분담</p>
+          <span>해커톤 프로젝트 데크</span>
+        </a>
       </div>
     </section>
 

--- a/docs/pages/practical_ai_study.html
+++ b/docs/pages/practical_ai_study.html
@@ -356,8 +356,8 @@
 
         <a class="resource" href="contextbridge-presentation.html" target="_blank" rel="noopener noreferrer">
           <div class="label">해커톤</div>
-          <strong>ContextBridge — Cross-layer 디버깅 근거 시스템</strong>
-          <p>7곳을 뒤지던 Camera HAL 디버깅을 질문 한 번으로 — 하나의 증상을 layer를 따라 추적해 근거 패키지로 묶어주는 해커톤 프로젝트 데크. Before/After, 데모, 아키텍처(수집·최신 유지·Cross-layer 검색·근거 패키지), 4주 계획, Evidence Pack, 역할 분담</p>
+          <strong>ContextBridge — Cross-layer RAG Gateway</strong>
+          <p>코드·로그·이슈·리뷰를 한곳에 모아 Agent가 근거를 갖고 일하게 하는 Cross-layer RAG Gateway(최신 Context DB)를 제안하는 해커톤 데크 — 7곳을 뒤지던 디버깅을 질문 한 번으로. Before/After, 데모, Why Cross-layer, 아키텍처(수집·최신 유지·Cross-layer 검색·근거 패키지), 4주 계획, Evidence Pack, 역할 분담</p>
           <span>해커톤 프로젝트 데크</span>
         </a>
       </div>


### PR DESCRIPTION
﻿## 요약
사용자 제공 발표 자료 `ContextBridge - Hackathon Deck.html`을 repo에 통합합니다.

- **추가**: `docs/pages/contextbridge-presentation.html` — ContextBridge 해커톤 데크(8슬라이드). 기존 `llm-wiki-presentation.html` / `rag-presentation.html`과 동일한 번들러 아티팩트 형식이라 원본을 **바이트 단위(SHA256 일치)로 무손실 복사**.
- **연결**: `docs/pages/practical_ai_study.html` 발표 자료 섹션에서 RAG 카드 바로 뒤에 `해커톤` 라벨 카드 추가.

## 배치 근거
발표 데크는 이 저장소에서 study 페이지 `#resources` "발표 자료" 그리드에만 존재합니다. ContextBridge는 LLM Wiki(맥락 *구조화*) · RAG(맥락 *검색·근거*) 개념을 실제 프로젝트(Cross-layer RAG Gateway)로 잇는 성격이라, 두 개념 데크 뒤에 세 번째 카드로 배치했습니다. 개념 explainer와 구분되도록 라벨은 `해커톤`으로 표기.

## 데크 구성 (8슬라이드)
Title(ContextBridge — Camera HAL/Driver Cross-layer RAG Gateway) → Before/After → Demo·Cross-layer → Why Cross-layer → Architecture(수집·최신 유지·Cross-layer 검색·근거 패키지) → 4-Week Plan → Evidence Pack ★ → Roles + Closing

## 검증
- 헤드리스 Edge 렌더링 통과 — "ContextBridge" 타이틀·8슬라이드 썸네일 레일·한국어 정상 표시 (푸터 `01 / 08`)
- study 페이지 렌더링 확인 — 카드 3개(Wiki/RAG/ContextBridge) 정상, 홀수(9개) 그리드에서 마지막 카드가 좌측 단독 배치되나 레이아웃 깨짐 없음
- 복사 무결성: src/dst 바이트(5,345,889) 및 SHA256 해시 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)
