### PR TITLE
docs: ContextBridge 데크 갱신(8→9슬라이드) + 카드에 Evidence Pack 효과 반영

### DIFF
--- a/docs/pages/practical_ai_study.html
+++ b/docs/pages/practical_ai_study.html
@@ -357,7 +357,7 @@
         <a class="resource" href="contextbridge-presentation.html" target="_blank" rel="noopener noreferrer">
           <div class="label">해커톤</div>
           <strong>ContextBridge — Cross-layer RAG Gateway</strong>
-          <p>코드·로그·이슈·리뷰를 한곳에 모아 Agent가 근거를 갖고 일하게 하는 Cross-layer RAG Gateway(최신 Context DB)를 제안하는 해커톤 데크 — 7곳을 뒤지던 디버깅을 질문 한 번으로. Before/After, 데모, Why Cross-layer, 아키텍처(수집·최신 유지·Cross-layer 검색·근거 패키지), 4주 계획, Evidence Pack, 역할 분담</p>
+          <p>코드·로그·이슈·리뷰를 한곳에 모아 Agent가 근거를 갖고 일하게 하는 Cross-layer RAG Gateway(최신 Context DB)를 제안하는 해커톤 데크 — 7곳을 뒤지던 디버깅을 질문 한 번으로. Before/After, 데모, Why Cross-layer, 아키텍처(수집·최신 유지·Cross-layer 검색·근거 패키지), 4주 계획, Evidence Pack·효과, 역할 분담</p>
           <span>해커톤 프로젝트 데크</span>
         </a>
       </div>


### PR DESCRIPTION
﻿## 요약
사용자가 갱신한 발표 자료 `ContextBridge - Hackathon Deck.html`을 반영합니다.

- **교체**: `docs/pages/contextbridge-presentation.html` — 갱신본으로 **바이트 단위(SHA256 일치) 무손실 교체 복사** (5,345,889 → 5,355,325 bytes). 아래 모든 슬라이드 변경이 이 통째 교체로 반영됨.
- **카드 반영**: `docs/pages/practical_ai_study.html`의 ContextBridge 카드 슬라이드 목록에 신규 슬라이드 반영.

## 무엇이 바뀌었나 (구·신 슬라이드 전수 대조)
- **신규 슬라이드**: `Evidence Pack Impact`(rail 08, "디버깅 초반이 이렇게 짧아진다" — 원인 파악·리뷰/triage 준비·반복/온보딩 단축). 8 → 9슬라이드, 푸터 `01/08` → `01/09`.
- **05 Architecture**: Hybrid Retrieval 구성 표현 수정 — `vector + exact code(rg) + symbol + structured + log/trace` → `vector · code search(rg) · symbol · issue/change filter · log/trace`.
- **06 4-Week Plan**: MVP 범위 밖 항목 문구 — `완벽한 ACL → mock filter로 구조만` → `사내 권한 완전 연동 → mock filter로 구조만`.
- **07 Evidence Pack ★**: 마무리 문구 추가 — `리뷰와 triage에 바로 재사용되는 근거 묶음 · 7곳 탐색 → Evidence Pack 1개`.
- **Title / Roles**: 슬라이드 번호·푸터 카운터만 변경(내용 동일).
- **동일**: Before/After, Demo · Cross-layer, Why Cross-layer.
- **제목·부제·논지 불변**: "Camera HAL/Driver를 위한 Cross-layer RAG Gateway" / "근거를 갖고 일하는 Camera Agent 인프라". 용어 비중은 근거 중심 강화(Evidence 29·근거 25 vs 디버깅 5).

## 카드 변경
`… 4주 계획, Evidence Pack, 역할 분담` → `… 4주 계획, Evidence Pack·효과, 역할 분담` (신규 Impact 슬라이드 반영). 제목("Cross-layer RAG Gateway")·라벨("해커톤")·span 유지. 05/06/07 문구 변경은 카드 고수준 요약(아키텍처·4주 계획·Evidence Pack 이름)과 상충하지 않아 추가 수정 없음.

## 검증
- 헤드리스 Edge 렌더링 통과 — 9슬라이드 썸네일 레일, 푸터 `01 / 09`, 제목·태그라인 정상.
- 구·신 슬라이드 전수 대조로 변경 항목 확정(위 목록).
- 복사 무결성: src/dst 바이트 및 SHA256 해시 일치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
